### PR TITLE
remove codesponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # Construct 2 Addon parser [![NPM version][npm-image]][npm-url]
 > A module to extract ACE table of a plugin
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/xUwNPd323FogQwpUUpKNVYuT/armaldio/c2-addon-parser'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/xUwNPd323FogQwpUUpKNVYuT/armaldio/c2-addon-parser.svg' />
-</a>
+
 
 ## Installation
 


### PR DESCRIPTION
Pull request automatically sent by knewzen <https://github.com/knewzen>. Because Code Sponsor is shutting down on December 8